### PR TITLE
Needs more testing, but systemd unit files are written and seem to launch metricsd and systemd-cloud-watch.

### DIFF
--- a/resources/etc/systemd/system/metricsd.service
+++ b/resources/etc/systemd/system/metricsd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=MetricsD OS Metrics
+Requires=cassandra.service
+After=cassandra.service
+
+[Service]
+ExecStart=/opt/cloudurable/bin/metricsd
+
+WorkingDirectory=/opt/cloudurable
+Restart=always
+RestartSec=60
+TimeoutStopSec=60
+TimeoutStartSec=60
+
+
+[Install]
+WantedBy=multi-user.target
+

--- a/resources/etc/systemd/system/systemd-cloud-watch.service
+++ b/resources/etc/systemd/system/systemd-cloud-watch.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SystemD Cloud Watch Sends Journald logs to CloudWatch
+Requires=cassandra.service
+After=cassandra.service
+
+[Service]
+ExecStart=/opt/cloudurable/bin/systemd-cloud-watch
+
+WorkingDirectory=/opt/cloudurable
+Restart=always
+RestartSec=60
+TimeoutStopSec=60
+TimeoutStartSec=60
+
+
+[Install]
+WantedBy=multi-user.target
+

--- a/scripts/050-systemd-setup.sh
+++ b/scripts/050-systemd-setup.sh
@@ -5,3 +5,14 @@ set -e
 cp ~/resources/etc/systemd/system/cassandra.service /etc/systemd/system/cassandra.service
 systemctl enable cassandra
 systemctl start  cassandra
+
+
+cp ~/resources/etc/systemd/system/metricsd.service /etc/systemd/system/metricsd.service
+systemctl enable metricsd
+systemctl start  metricsd
+
+cp ~/resources/etc/systemd/system/systemd-cloud-watch.service /etc/systemd/system/systemd-cloud-watch.service
+systemctl enable systemd-cloud-watch
+systemctl start  systemd-cloud-watch
+
+


### PR DESCRIPTION
Needs more testing, but systemd unit files are written and seem to launch metricsd and systemd-cloud-watch.

To startup the complete cluster, just run `vagrant up`.

Be sure to run bin/prepare-binaries.sh first to download and check the sha signatures of the binaries. 